### PR TITLE
Ignore action-slack-notify

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -185,6 +185,7 @@ runs:
     -
       name: Slack notification on failure
       uses: rtCamp/action-slack-notify@v2
+      continue-on-error: true
       if: env.DEPLOY_CONFIRM == 'true' && env.DEPLOY_OUTCOME == 'failure'
       env:
         SLACK_TITLE: "Deploy of ${{ env.NAMESPACE }} ${{ env.HELM_RELEASE }} failed."


### PR DESCRIPTION
1. Due to https://github.com/rtCamp/action-slack-notify/issues/126#issue-1280034198, ignore action-slack-notify until the issue is fixed